### PR TITLE
Added new way of defining selectors for Elements and InlineElements

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -316,6 +316,87 @@ The simplest way to use elements is to define them inline in the page class:
 The advantage of this approach is that all the important page elements
 are defined in one place and we can reference them from multiple methods.
 
+Also you may define elements with more object oriented approach, simple by defining Page::createSelectors method:
+
+    .. code-block:: php
+
+        <?php
+
+        use SensioLabs\Behat\PageObjectExtension\PageObject\Page;
+        use SensioLabs\Behat\PageObjectExtension\PageObject\Selector\CssSelector;
+        use SensioLabs\Behat\PageObjectExtension\PageObject\Selector\XpathSelector;
+
+        class Homepage extends Page
+        {
+            // ...
+
+            /**
+             * {@inheritdoc}
+             */
+            protected function createSelectors()
+            {
+                $this->addSelector('Search form', new CssSelector('form#search'));
+                $this->addSelector('Navigation', new CssSelector('.header div.navigation'));
+                $this->addSelector('Article list', new XpathSelector('//*[contains(@class, "content")]//ul[contains(@class, "articles")]');
+            }
+
+            /**
+             * @param string $keywords
+             *
+             * @return Page
+             */
+            public function search($keywords)
+            {
+                $searchForm = $this->getElement('Search form');
+                $searchForm->fillField('q', $keywords);
+                $searchForm->pressButton('Google Search');
+
+                return $this->getPage('Search results');
+            }
+        }
+
+it is also possible to mix both definitions:
+
+    .. code-block:: php
+
+        <?php
+
+        use SensioLabs\Behat\PageObjectExtension\PageObject\Page;
+        use SensioLabs\Behat\PageObjectExtension\PageObject\Selector\CssSelector;
+        use SensioLabs\Behat\PageObjectExtension\PageObject\Selector\XpathSelector;
+
+        class Homepage extends Page
+        {
+            // ...
+
+            protected $elements = array(
+                'Search form' => array('css' => 'form#search')
+            );
+
+            /**
+             * {@inheritdoc}
+             */
+            protected function createSelectors()
+            {
+                $this->addSelector('Navigation', new CssSelector('.header div.navigation'));
+                $this->addSelector('Article list', new XpathSelector('//*[contains(@class, "content")]//ul[contains(@class, "articles")]');
+            }
+
+            /**
+             * @param string $keywords
+             *
+             * @return Page
+             */
+            public function search($keywords)
+            {
+                $searchForm = $this->getElement('Search form');
+                $searchForm->fillField('q', $keywords);
+                $searchForm->pressButton('Google Search');
+
+                return $this->getPage('Search results');
+            }
+        }
+
 Custom elements
 ~~~~~~~~~~~~~~~
 
@@ -359,6 +440,37 @@ Here's a previous search example modeled as an element:
 Definining the ``$selector`` property is optional but recommended. When defined,
 it will limit all the operations on the page to the area withing the selector.
 Any selector supported by Mink can be used here.
+
+Also you may define limit selector using SelectorInterface implementations, simply create method getSelector():
+
+    .. code-block:: php
+
+        <?php
+
+        use SensioLabs\Behat\PageObjectExtension\PageObject\Element;
+        use SensioLabs\Behat\PageObjectExtension\PageObject\Page;
+        use SensioLabs\Behat\PageObjectExtension\PageObject\Selector\CssSelector;
+
+        class SearchForm extends Element
+        {
+            protected function getSelector()
+            {
+                return new CssSelector('div.content');
+            }
+
+            /**
+             * @param string $keywords
+             *
+             * @return Page
+             */
+            public function search($keywords)
+            {
+                $this->fillField('q', $keywords);
+                $this->pressButton('Google Search');
+
+                return $this->getPage('Search results');
+            }
+        }
 
 Accessing custom elements is much like accessing inline ones:
 

--- a/spec/SensioLabs/Behat/PageObjectExtension/ExtensionSpec.php
+++ b/spec/SensioLabs/Behat/PageObjectExtension/ExtensionSpec.php
@@ -18,6 +18,7 @@ class ExtensionSpec extends ObjectBehavior
     {
         $this->servicesShouldBeRegistered($container, array(
             'sensio_labs.page_object_extension.page_factory',
+            'sensio_labs.page_object_extension.selector_factory',
             'sensio_labs.page_object_extension.context.initializer'
         ), $parameterBag);
 

--- a/spec/SensioLabs/Behat/PageObjectExtension/PageObject/ElementSpec.php
+++ b/spec/SensioLabs/Behat/PageObjectExtension/PageObject/ElementSpec.php
@@ -8,6 +8,8 @@ use PhpSpec\ObjectBehavior;
 use SensioLabs\Behat\PageObjectExtension\Context\PageFactoryInterface;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Element as BaseElement;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Page;
+use SensioLabs\Behat\PageObjectExtension\PageObject\Selector\SelectorFactoryInterface;
+use SensioLabs\Behat\PageObjectExtension\PageObject\Selector\SelectorInterface;
 
 class MyElement extends BaseElement
 {
@@ -26,11 +28,18 @@ class MyElement extends BaseElement
 
 class ElementSpec extends ObjectBehavior
 {
-    function let(Session $session, PageFactoryInterface $factory, SelectorsHandler $selectorsHandler)
+    function let(Session $session, PageFactoryInterface $factory, SelectorFactoryInterface $selectorFactory, SelectorsHandler $selectorsHandler, SelectorInterface $selector)
     {
         // until we have proper abstract class support in PhpSpec
         $this->beAnInstanceOf('spec\SensioLabs\Behat\PageObjectExtension\PageObject\MyElement');
-        $this->beConstructedWith($session, $factory);
+        $this->beConstructedWith($session, $factory, $selectorFactory);
+
+        $type = 'xpath';
+        $path = '//div[@id="my-box"]';
+        $selectorFactory->create(array($type => $path))->willReturn($selector);
+        $selector->getPath()->willReturn($path);
+        $selector->getType()->willReturn($type);
+        $selector->asArray()->willReturn(array($type => $path));
 
         $session->getSelectorsHandler()->willReturn($selectorsHandler);
         $selectorsHandler->selectorToXpath('xpath', '//div[@id="my-box"]')->willReturn('//div[@id="my-box"]');

--- a/spec/SensioLabs/Behat/PageObjectExtension/PageObject/PageSpec.php
+++ b/spec/SensioLabs/Behat/PageObjectExtension/PageObject/PageSpec.php
@@ -5,16 +5,26 @@ namespace spec\SensioLabs\Behat\PageObjectExtension\PageObject;
 use Behat\Mink\Exception\DriverException;
 use Behat\Mink\Session;
 use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
 use SensioLabs\Behat\PageObjectExtension\Context\PageFactoryInterface;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Element;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\PathNotProvidedException;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\UnexpectedPageException;
 use SensioLabs\Behat\PageObjectExtension\PageObject\InlineElement;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Page as BasePage;
+use SensioLabs\Behat\PageObjectExtension\PageObject\Selector\CssSelector;
+use SensioLabs\Behat\PageObjectExtension\PageObject\Selector\SelectorFactoryInterface;
+use SensioLabs\Behat\PageObjectExtension\PageObject\Selector\SelectorInterface;
+use SensioLabs\Behat\PageObjectExtension\PageObject\Selector\XpathSelector;
 
 class MyPage extends BasePage
 {
     protected $path = '/employees/{employee}';
+
+    public function getSelectors()
+    {
+        return $this->selectors;
+    }
 
     public function callGetPage($name)
     {
@@ -34,10 +44,19 @@ class MyPage extends BasePage
 
 class MyPageWithoutPath extends BasePage
 {
+    public function getSelectors()
+    {
+        return $this->selectors;
+    }
 }
 
 class MyPageWithValidation extends MyPage
 {
+    public function getSelectors()
+    {
+        return $this->selectors;
+    }
+
     protected function verifyPage()
     {
         throw new UnexpectedPageException('Expected to be on "MyPage" but found "Homepage" instead');
@@ -51,19 +70,63 @@ class MyPageWithInlineElements extends BasePage
         'Search form' => array('css' => 'div.content form#search')
     );
 
+    public function getSelectors()
+    {
+        return $this->selectors;
+    }
+
     public function callGetElement($name)
     {
         return $this->getElement($name);
+    }
+
+    protected function createSelectors()
+    {
+        $this->addSelector('Menu', new CssSelector('div.menu'));
+        $this->addSelector('Footer links', new XpathSelector('//div/ul/li/a'));
+    }
+}
+
+class MyPageWithInlineElementsObjectSelectorsOnly extends BasePage
+{
+    public function getSelectors()
+    {
+        return $this->selectors;
+    }
+
+    public function callGetElement($name)
+    {
+        return $this->getElement($name);
+    }
+
+    protected function createSelectors()
+    {
+        $this->addSelector('Menu', new CssSelector('div.menu'));
+        $this->addSelector('Footer links', new XpathSelector('//div/ul/li/a'));
+    }
+}
+
+// this class is created only for constructor exceptions tests
+abstract class MyPageWithInvalidInlineElementsWrapper extends BasePage
+{
+    public function __construct($callParent = false, Session $session = null, PageFactoryInterface $pageFactory = null,
+        SelectorFactoryInterface $selectorFactory = null, array $parameters = array())
+    {
+        if ($callParent) {
+            parent::__construct($session, $pageFactory, $selectorFactory, $parameters);
+        }
     }
 }
 
 class PageSpec extends ObjectBehavior
 {
-    function let(Session $session, PageFactoryInterface $factory)
+    function let(Session $session, PageFactoryInterface $factory, SelectorFactoryInterface $selectorFactory, SelectorInterface $selector)
     {
         // until we have proper abstract class support in PhpSpec
         $this->beAnInstanceOf('spec\SensioLabs\Behat\PageObjectExtension\PageObject\MyPage');
-        $this->beConstructedWith($session, $factory);
+        $this->beConstructedWith($session, $factory, $selectorFactory);
+
+        $selectorFactory->create(Argument::any())->willReturn($selector);
     }
 
     function it_should_be_a_document_element()
@@ -79,9 +142,9 @@ class PageSpec extends ObjectBehavior
         $this->open(array('employee' => 13))->shouldReturn($this);
     }
 
-    function it_prepends_base_url($session, $factory)
+    function it_prepends_base_url($session, $factory, $selectorFactory)
     {
-        $this->beConstructedWith($session, $factory, array('base_url' => 'http://behat.dev/'));
+        $this->beConstructedWith($session, $factory, $selectorFactory, array('base_url' => 'http://behat.dev/'));
 
         $session->visit('http://behat.dev/employees/13')->shouldBeCalled();
         $session->getStatusCode()->willReturn(200);
@@ -89,9 +152,9 @@ class PageSpec extends ObjectBehavior
         $this->open(array('employee' => 13))->shouldReturn($this);
     }
 
-    function it_cleans_up_slashes($session, $factory)
+    function it_cleans_up_slashes($session, $factory, $selectorFactory)
     {
-        $this->beConstructedWith($session, $factory, array('base_url' => 'http://behat.dev/'));
+        $this->beConstructedWith($session, $factory, $selectorFactory, array('base_url' => 'http://behat.dev/'));
 
         $session->visit('http://behat.dev/employees/13')->shouldBeCalled();
         $session->getStatusCode()->willReturn(200);
@@ -107,10 +170,10 @@ class PageSpec extends ObjectBehavior
         $this->open()->shouldReturn($this);
     }
 
-    function it_requires_path_to_open_a_page($session, $factory)
+    function it_requires_path_to_open_a_page($session, $factory, $selectorFactory)
     {
         $this->beAnInstanceOf('spec\SensioLabs\Behat\PageObjectExtension\PageObject\MyPageWithoutPath');
-        $this->beConstructedWith($session, $factory);
+        $this->beConstructedWith($session, $factory, $selectorFactory);
 
         $this->shouldThrow(new PathNotProvidedException('You must add a path property to your page object'))
             ->duringOpen();
@@ -144,10 +207,10 @@ class PageSpec extends ObjectBehavior
         $this->open(array('employee' => 13))->shouldReturn($this);
     }
 
-    function it_optionally_verifies_the_page($session, $factory)
+    function it_optionally_verifies_the_page($session, $factory, $selectorFactory)
     {
         $this->beAnInstanceOf('spec\SensioLabs\Behat\PageObjectExtension\PageObject\MyPageWithValidation');
-        $this->beConstructedWith($session, $factory);
+        $this->beConstructedWith($session, $factory, $selectorFactory);
 
         $session->visit('/employees/13')->shouldBeCalled();
         $session->getStatusCode()->willReturn(200);
@@ -155,9 +218,9 @@ class PageSpec extends ObjectBehavior
         $this->shouldThrow(new UnexpectedPageException('Expected to be on "MyPage" but found "Homepage" instead'))->duringOpen(array('employee' => 13));
     }
 
-    function it_gives_clear_feedback_if_method_is_invalid($session, $factory)
+    function it_gives_clear_feedback_if_method_is_invalid($session, $factory, $selectorFactory)
     {
-        $this->beConstructedWith($session, $factory, array('base_url' => 'http://behat.dev/'));
+        $this->beConstructedWith($session, $factory, $selectorFactory, array('base_url' => 'http://behat.dev/'));
 
         $this->shouldThrow(new \BadMethodCallException('"search" method is not available on the MyPage'))->during('search');
     }
@@ -176,12 +239,15 @@ class PageSpec extends ObjectBehavior
         $this->callGetElement('Navigation')->shouldReturn($element);
     }
 
-    function it_creates_an_inline_element_if_present($session, $factory, InlineElement $element)
+    function it_creates_an_inline_element_if_present($session, $factory, $selectorFactory, InlineElement $element, SelectorInterface $selector)
     {
         $this->beAnInstanceOf('spec\SensioLabs\Behat\PageObjectExtension\PageObject\MyPageWithInlineElements');
-        $this->beConstructedWith($session, $factory);
+        $this->beConstructedWith($session, $factory, $selectorFactory);
 
-        $factory->createInlineElement(array('xpath' => '//div/span[@class="navigation"]'))->willReturn($element);
+        $this->create_selector($selector, 'xpath', '//div/span[@class="navigation"]');
+
+        $factory->createInlineElement(Argument::type('SensioLabs\Behat\PageObjectExtension\PageObject\Selector\SelectorInterface'))
+            ->willReturn($element);
 
         $this->callGetElement('Navigation')->shouldReturn($element);
     }
@@ -189,5 +255,53 @@ class PageSpec extends ObjectBehavior
     function it_returns_the_page_name()
     {
         $this->callGetName()->shouldReturn('MyPage');
+    }
+
+    function it_converts_array_elements_into_selector_instances($session, $factory, $selectorFactory)
+    {
+        $this->beAnInstanceOf('spec\SensioLabs\Behat\PageObjectExtension\PageObject\MyPageWithInlineElements');
+        $this->beConstructedWith($session, $factory, $selectorFactory);
+
+        $this->getSelectors()->shouldBeAnInstanceOf('Symfony\Component\DependencyInjection\ParameterBag\ParameterBag');
+        $this->getSelectors()->get('Navigation')->shouldBeAnInstanceOf('SensioLabs\Behat\PageObjectExtension\PageObject\Selector\SelectorInterface');
+        $this->getSelectors()->get('Search form')->shouldBeAnInstanceOf('SensioLabs\Behat\PageObjectExtension\PageObject\Selector\SelectorInterface');
+        $this->getSelectors()->shouldHaveSelectorsCount(4);
+    }
+
+    function it_merges_elements_with_object_selectors($session, $factory, $selectorFactory)
+    {
+        $this->beAnInstanceOf('spec\SensioLabs\Behat\PageObjectExtension\PageObject\MyPageWithInlineElements');
+        $this->beConstructedWith($session, $factory, $selectorFactory);
+
+        $this->getSelectors()->get('Menu')->shouldBeAnInstanceOf('SensioLabs\Behat\PageObjectExtension\PageObject\Selector\CssSelector');
+        $this->getSelectors()->get('Footer links')->shouldBeAnInstanceOf('SensioLabs\Behat\PageObjectExtension\PageObject\Selector\XpathSelector');
+        $this->getSelectors()->shouldHaveSelectorsCount(4);
+    }
+
+    function it_creates_selectors_from_method($session, $factory, $selectorFactory)
+    {
+        $this->beAnInstanceOf('spec\SensioLabs\Behat\PageObjectExtension\PageObject\MyPageWithInlineElementsObjectSelectorsOnly');
+        $this->beConstructedWith($session, $factory, $selectorFactory);
+
+        $this->getSelectors()->get('Menu')->shouldBeAnInstanceOf('SensioLabs\Behat\PageObjectExtension\PageObject\Selector\CssSelector');
+        $this->getSelectors()->get('Footer links')->shouldBeAnInstanceOf('SensioLabs\Behat\PageObjectExtension\PageObject\Selector\XpathSelector');
+        $this->getSelectors()->shouldHaveSelectorsCount(2);
+    }
+
+
+    public function getMatchers()
+    {
+        return array(
+            'haveSelectorsCount' => function($subject, $expected) {
+                return (count($subject->all()) === $expected);
+            }
+        );
+    }
+
+    private function create_selector(SelectorInterface $selector, $type, $path)
+    {
+        $selector->getPath()->willReturn($path);
+        $selector->getType()->willReturn($type);
+        $selector->asArray()->willReturn(array($type => $path));
     }
 }

--- a/spec/SensioLabs/Behat/PageObjectExtension/PageObject/Selector/CssSelectorSpec.php
+++ b/spec/SensioLabs/Behat/PageObjectExtension/PageObject/Selector/CssSelectorSpec.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace spec\SensioLabs\Behat\PageObjectExtension\PageObject\Selector;
+
+require_once __DIR__.DIRECTORY_SEPARATOR.'SelectorBehavior.php';
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class CssSelectorSpec extends SelectorBehavior
+{
+    function getExpectedPath()
+    {
+        return 'span.nice';
+    }
+
+    function getExpectedType()
+    {
+        return 'css';
+    }
+}

--- a/spec/SensioLabs/Behat/PageObjectExtension/PageObject/Selector/SelectorBehavior.php
+++ b/spec/SensioLabs/Behat/PageObjectExtension/PageObject/Selector/SelectorBehavior.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace spec\SensioLabs\Behat\PageObjectExtension\PageObject\Selector;
+
+use PhpSpec\ObjectBehavior;
+
+abstract class SelectorBehavior extends ObjectBehavior
+{
+    function let()
+    {
+        $this->beConstructedWith($this->getExpectedPath());
+    }
+
+    function it_returns_css_type()
+    {
+        $this->getType()->shouldBe($this->getExpectedType());
+    }
+
+    function it_returns_path()
+    {
+        $this->getPath()->shouldBe($this->getExpectedPath());
+    }
+
+    function it_returns_array_selector()
+    {
+        $this->asArray()->shouldBe(array($this->getExpectedType() => $this->getExpectedPath()));
+    }
+
+    abstract function getExpectedPath();
+
+    abstract function getExpectedType();
+}

--- a/spec/SensioLabs/Behat/PageObjectExtension/PageObject/Selector/SelectorFactorySpec.php
+++ b/spec/SensioLabs/Behat/PageObjectExtension/PageObject/Selector/SelectorFactorySpec.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace spec\SensioLabs\Behat\PageObjectExtension\PageObject\Selector;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class SelectorFactorySpec extends ObjectBehavior
+{
+    const SELECTOR_CSS = 'SensioLabs\Behat\PageObjectExtension\PageObject\Selector\CssSelector';
+    const SELECTOR_XPATH = 'SensioLabs\Behat\PageObjectExtension\PageObject\Selector\XpathSelector';
+
+    function let()
+    {
+        $this->registry('css', self::SELECTOR_CSS);
+        $this->registry('xpath', self::SELECTOR_XPATH);
+    }
+
+    function it_creates_new_selector_from_array_args()
+    {
+        $this->create(array('xpath' => '//'))->shouldBeAnInstanceOf(self::SELECTOR_XPATH);
+    }
+
+    function it_creates_new_selector_from_args()
+    {
+        $this->create('css', 'div.test')->shouldBeAnInstanceOf(self::SELECTOR_CSS);
+    }
+
+    function it_throws_an_exception_for_missing_selector_type()
+    {
+        $this->shouldThrow('\SensioLabs\Behat\PageObjectExtension\PageObject\Exception\InvalidSelectorDeclarationException')
+            ->duringCreate('non', 'div.test');
+    }
+
+    function it_throws_an_exception_for_invalid_selector_declarations()
+    {
+        $invalid = array(
+            array('css', 'div.test'),
+            'css',
+            null,
+            array(''),
+            array(0 => 'test')
+        );
+
+        foreach ($invalid as $declaration) {
+            $this->shouldThrow('\SensioLabs\Behat\PageObjectExtension\PageObject\Exception\InvalidSelectorDeclarationException')
+                ->duringCreate($invalid);
+        }
+
+        $invalid = array(
+            array(null, null),
+            array(null, 'test'),
+            array(null, array()),
+        );
+
+        foreach ($invalid as $declaration) {
+            $this->shouldThrow('\SensioLabs\Behat\PageObjectExtension\PageObject\Exception\InvalidSelectorDeclarationException')
+                ->duringCreate($declaration[0], $declaration[1]);
+        }
+    }
+
+    function it_throws_an_exception_for_empty_declaration()
+    {
+        $this->shouldThrow('\SensioLabs\Behat\PageObjectExtension\PageObject\Exception\InvalidSelectorDeclarationException')
+            ->duringCreate();
+    }
+
+    function it_throws_an_exception_for_more_than_two_arguments_declaration()
+    {
+        $this->shouldThrow('\SensioLabs\Behat\PageObjectExtension\PageObject\Exception\InvalidSelectorDeclarationException')
+            ->duringCreate('css', 'div.nice', true);
+    }
+}

--- a/spec/SensioLabs/Behat/PageObjectExtension/PageObject/Selector/XpathSelectorSpec.php
+++ b/spec/SensioLabs/Behat/PageObjectExtension/PageObject/Selector/XpathSelectorSpec.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace spec\SensioLabs\Behat\PageObjectExtension\PageObject\Selector;
+
+require_once __DIR__.DIRECTORY_SEPARATOR.'SelectorBehavior.php';
+
+use Prophecy\Argument;
+
+class XpathSelectorSpec extends SelectorBehavior
+{
+    function getExpectedPath()
+    {
+        return '//div/span[@class="navigation"]';
+    }
+
+    function getExpectedType()
+    {
+        return 'xpath';
+    }
+}

--- a/src/SensioLabs/Behat/PageObjectExtension/PageObject/Element.php
+++ b/src/SensioLabs/Behat/PageObjectExtension/PageObject/Element.php
@@ -6,28 +6,36 @@ use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Selector\SelectorsHandler;
 use Behat\Mink\Session;
 use SensioLabs\Behat\PageObjectExtension\Context\PageFactoryInterface;
+use SensioLabs\Behat\PageObjectExtension\PageObject\Selector\SelectorFactoryInterface;
 
 abstract class Element extends NodeElement
 {
-    /**
-     * @var array|string $selector
-     */
-    protected $selector = array('xpath' => '//');
-
     /**
      * @var PageFactoryInterface $pageFactory
      */
     private $pageFactory = null;
 
     /**
-     * @param Session              $session
-     * @param PageFactoryInterface $pageFactory
+     * @var SelectorFactoryInterface
      */
-    public function __construct(Session $session, PageFactoryInterface $pageFactory)
-    {
-        parent::__construct($this->getSelectorAsXpath($session->getSelectorsHandler()), $session);
+    private $selectorFactory;
 
+    /**
+     * @var array
+     */
+    protected $selector = array('xpath' => '//');
+
+    /**
+     * @param Session                  $session
+     * @param PageFactoryInterface     $pageFactory
+     * @param SelectorFactoryInterface $selectorFactory
+     */
+    public function __construct(Session $session, PageFactoryInterface $pageFactory, SelectorFactoryInterface $selectorFactory)
+    {
+        $this->selectorFactory = $selectorFactory;
         $this->pageFactory = $pageFactory;
+
+        parent::__construct($this->getSelectorAsXpath($session->getSelectorsHandler()), $session);
     }
 
     /**
@@ -60,15 +68,25 @@ abstract class Element extends NodeElement
     }
 
     /**
+     * Return scope limit selector
+     */
+    protected function getSelector()
+    {
+        return $this->selectorFactory->create($this->selector);
+    }
+
+    /**
      * @param SelectorsHandler $selectorsHandler
      *
      * @return string
      */
     private function getSelectorAsXpath(SelectorsHandler $selectorsHandler)
     {
-        $selectorType = key($this->selector);
-        $locator = $this->selector[$selectorType];
+        $selector = $this->getSelector();
+        if ($selector == null) {
+            return null;
+        }
 
-        return $selectorsHandler->selectorToXpath($selectorType, $locator);
+        return $selectorsHandler->selectorToXpath($selector->getType(), $selector->getPath());
     }
 }

--- a/src/SensioLabs/Behat/PageObjectExtension/PageObject/Exception/InvalidPageDeclarationException.php
+++ b/src/SensioLabs/Behat/PageObjectExtension/PageObject/Exception/InvalidPageDeclarationException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace SensioLabs\Behat\PageObjectExtension\PageObject\Exception;
+
+class InvalidPageDeclarationException extends \Exception
+{
+}

--- a/src/SensioLabs/Behat/PageObjectExtension/PageObject/Exception/InvalidSelectorDeclarationException.php
+++ b/src/SensioLabs/Behat/PageObjectExtension/PageObject/Exception/InvalidSelectorDeclarationException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace SensioLabs\Behat\PageObjectExtension\PageObject\Exception;
+
+class InvalidSelectorDeclarationException extends \Exception
+{
+}

--- a/src/SensioLabs/Behat/PageObjectExtension/PageObject/InlineElement.php
+++ b/src/SensioLabs/Behat/PageObjectExtension/PageObject/InlineElement.php
@@ -4,6 +4,7 @@ namespace SensioLabs\Behat\PageObjectExtension\PageObject;
 
 use Behat\Mink\Session;
 use SensioLabs\Behat\PageObjectExtension\Context\PageFactoryInterface;
+use SensioLabs\Behat\PageObjectExtension\PageObject\Selector\SelectorFactoryInterface;
 
 class InlineElement extends Element
 {
@@ -13,14 +14,15 @@ class InlineElement extends Element
     protected $selector = null;
 
     /**
-     * @param array|string         $selector
-     * @param Session              $session
-     * @param PageFactoryInterface $pageFactory
+     * @param array|string             $selector
+     * @param Session                  $session
+     * @param PageFactoryInterface     $pageFactory
+     * @param SelectorFactoryInterface $selectorFactory
      */
-    public function __construct($selector, Session $session, PageFactoryInterface $pageFactory)
+    public function __construct($selector, Session $session, PageFactoryInterface $pageFactory, SelectorFactoryInterface $selectorFactory)
     {
         $this->selector = $selector;
 
-        parent::__construct($session, $pageFactory);
+        parent::__construct($session, $pageFactory, $selectorFactory);
     }
 }

--- a/src/SensioLabs/Behat/PageObjectExtension/PageObject/Selector.php
+++ b/src/SensioLabs/Behat/PageObjectExtension/PageObject/Selector.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace SensioLabs\Behat\PageObjectExtension\PageObject;
+
+use SensioLabs\Behat\PageObjectExtension\PageObject\Selector\SelectorInterface;
+
+abstract class Selector implements SelectorInterface
+{
+    /**
+     * @var string
+     */
+    private $path;
+
+    /**
+     * @param string $path
+     */
+    public function __construct($path)
+    {
+        $this->path = $path;
+    }
+
+    /**
+     * Return path for current selector
+     *
+     * @return string
+     */
+    public function getPath()
+    {
+        return $this->path;
+    }
+
+    /**
+     * Return array representation of selector for PageFactory::createInlineElement
+     *
+     * @return array
+     */
+    public function asArray()
+    {
+        return array($this->getType() => $this->getPath());
+    }
+}

--- a/src/SensioLabs/Behat/PageObjectExtension/PageObject/Selector/CssSelector.php
+++ b/src/SensioLabs/Behat/PageObjectExtension/PageObject/Selector/CssSelector.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace SensioLabs\Behat\PageObjectExtension\PageObject\Selector;
+
+use SensioLabs\Behat\PageObjectExtension\PageObject\Selector;
+
+class CssSelector extends Selector implements SelectorInterface
+{
+    /**
+     * Return css type for selector
+     *
+     * @return string
+     */
+    public function getType()
+    {
+        return 'css';
+    }
+}

--- a/src/SensioLabs/Behat/PageObjectExtension/PageObject/Selector/SelectorFactory.php
+++ b/src/SensioLabs/Behat/PageObjectExtension/PageObject/Selector/SelectorFactory.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace SensioLabs\Behat\PageObjectExtension\PageObject\Selector;
+
+use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\InvalidSelectorDeclarationException;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+
+class SelectorFactory implements SelectorFactoryInterface
+{
+    /**
+     * Map of registered selectors supported by this factory
+     *
+     * @var ParameterBag
+     */
+    protected $selectorsMap;
+
+    /**
+     * Create factory
+     */
+    public function __construct()
+    {
+        $this->selectorsMap = new ParameterBag();
+    }
+
+    /**
+     * Registry new type of selector
+     *
+     * @param string $type  Type of selector
+     * @param string $class Class
+     */
+    public function registry($type, $class)
+    {
+        $this->selectorsMap->set($type, $class);
+    }
+
+    /**
+     * Creates selector from given arguments.
+     *
+     * Possible calls:
+     * - SelectorFactory::create(array('css', 'div.light'));
+     * - SelectorFactory::create('css', 'div.light');
+     *
+     * @return SelectorInterface
+     * @throws \SensioLabs\Behat\PageObjectExtension\PageObject\Exception\InvalidSelectorDefinitionException
+     */
+    public function create()
+    {
+        $args = func_get_args();
+        $argno = func_num_args();
+        switch (true) {
+            case ($argno == 1 && is_array($args[0])):
+                return $this->createSelectorFrom($args[0]);
+                break;
+            case ($argno == 2 && is_string($args[0]) && is_string($args[1])):
+                return $this->createSelector($args[0], $argno[1]);
+                break;
+            default:
+                throw new InvalidSelectorDeclarationException("Invalid SelectorFactory::create call, expected array or string.");
+        }
+    }
+
+    /**
+     * Create selector for given parameters
+     *
+     * @param $type
+     * @param $path
+     *
+     * @throws \SensioLabs\Behat\PageObjectExtension\PageObject\Exception\InvalidSelectorDeclarationException
+     * @return SelectorInterface
+     */
+    private function createSelector($type, $path)
+    {
+        if (!$this->selectorsMap->has($type)) {
+            throw new InvalidSelectorDeclarationException(
+                sprintf('Array definition should contain only css or xpath selector elements, but definition for %s has been found.', $type)
+            );
+        }
+
+        $class = $this->selectorsMap->get($type);
+
+        return new $class($path);
+    }
+
+    /**
+     * @param array $array
+     *
+     * @return SelectorInterface
+     */
+    private function createSelectorFrom(array $array)
+    {
+        $key = key($array);
+        return $this->createSelector($key, $array[$key]);
+    }
+}

--- a/src/SensioLabs/Behat/PageObjectExtension/PageObject/Selector/SelectorFactoryInterface.php
+++ b/src/SensioLabs/Behat/PageObjectExtension/PageObject/Selector/SelectorFactoryInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace SensioLabs\Behat\PageObjectExtension\PageObject\Selector;
+
+interface SelectorFactoryInterface
+{
+    /**
+     * Create Selector from given parameters
+     *
+     * @return SelectorInterface
+     */
+    public function create();
+}

--- a/src/SensioLabs/Behat/PageObjectExtension/PageObject/Selector/SelectorInterface.php
+++ b/src/SensioLabs/Behat/PageObjectExtension/PageObject/Selector/SelectorInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace SensioLabs\Behat\PageObjectExtension\PageObject\Selector;
+
+interface SelectorInterface
+{
+    /**
+     * Return type of selector
+     *
+     * @return string
+     */
+    public function getType();
+
+    /**
+     * Return path for selector
+     *
+     * @return string
+     */
+    public function getPath();
+
+    /**
+     * Return array representation of selector used by PageFactory::createInlineElement
+     *
+     * @return array
+     */
+    public function asArray();
+}

--- a/src/SensioLabs/Behat/PageObjectExtension/PageObject/Selector/XpathSelector.php
+++ b/src/SensioLabs/Behat/PageObjectExtension/PageObject/Selector/XpathSelector.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace SensioLabs\Behat\PageObjectExtension\PageObject\Selector;
+
+use SensioLabs\Behat\PageObjectExtension\PageObject\Selector;
+
+class XpathSelector extends Selector implements SelectorInterface
+{
+    /**
+     * Return xpath type for selector
+     *
+     * @return string
+     */
+    public function getType()
+    {
+        return 'xpath';
+    }
+}

--- a/src/SensioLabs/Behat/PageObjectExtension/services/core.xml
+++ b/src/SensioLabs/Behat/PageObjectExtension/services/core.xml
@@ -7,18 +7,35 @@
         <parameter key="sensio_labs.page_object_extension.namespaces.page" type="constant">null</parameter>
         <parameter key="sensio_labs.page_object_extension.namespaces.element" type="constant">null</parameter>
         <parameter key="sensio_labs.page_object_extension.page_factory.class">SensioLabs\Behat\PageObjectExtension\Context\PageFactory</parameter>
+        <parameter key="sensio_labs.page_object_extension.selector_factory.class">SensioLabs\Behat\PageObjectExtension\PageObject\Selector\SelectorFactory</parameter>
+
+        <parameter key="sensio_labs.page_object_extension.selector.css_selector.class">SensioLabs\Behat\PageObjectExtension\PageObject\Selector\CssSelector</parameter>
+        <parameter key="sensio_labs.page_object_extension.selector.xpath_selector.class">SensioLabs\Behat\PageObjectExtension\PageObject\Selector\XpathSelector</parameter>
+
         <parameter key="sensio_labs.page_object_extension.context.initializer.class">SensioLabs\Behat\PageObjectExtension\Context\Initializer\PageObjectAwareInitializer</parameter>
     </parameters>
 
     <services>
         <service id="sensio_labs.page_object_extension.page_factory" class="%sensio_labs.page_object_extension.page_factory.class%" public="false">
             <argument type="service" id="behat.mink" />
+            <argument type="service" id="sensio_labs.page_object_extension.selector_factory" />
             <argument>%behat.mink.parameters%</argument>
             <call method="setPageNamespace">
                 <argument>%sensio_labs.page_object_extension.namespaces.page%</argument>
             </call>
             <call method="setElementNamespace">
                 <argument>%sensio_labs.page_object_extension.namespaces.element%</argument>
+            </call>
+        </service>
+
+        <service id="sensio_labs.page_object_extension.selector_factory" class="%sensio_labs.page_object_extension.selector_factory.class%" public="false">
+            <call method="registry">
+                <argument>css</argument>
+                <argument>%sensio_labs.page_object_extension.selector.css_selector.class%</argument>
+            </call>
+            <call method="registry">
+                <argument>xpath</argument>
+                <argument>%sensio_labs.page_object_extension.selector.xpath_selector.class%</argument>
             </call>
         </service>
 


### PR DESCRIPTION
Introduced CssSelector and XpathSelector both can be used as a alternative for property based definition for inline elements.
