### PR TITLE
Added getter for PageFactory

### DIFF
--- a/src/SensioLabs/Behat/PageObjectExtension/Context/PageObjectContext.php
+++ b/src/SensioLabs/Behat/PageObjectExtension/Context/PageObjectContext.php
@@ -53,4 +53,12 @@ class PageObjectContext extends BehatContext implements PageObjectAwareInterface
     {
         $this->pageFactory = $pageFactory;
     }
+
+    /**
+     * @return PageFactory
+     */
+    public function getPageFactory()
+    {
+        return $this->pageFactory;
+    }
 }


### PR DESCRIPTION
I need Pages Object to belong to two different websites and its classes sit on separate namespaces. So I need to be able to overwrite the namespace on @BeforeScenario.

Since pageFactory is a private property I had no way to redefine it on runtime, to circumvent that I added a getter so I can change a re-set it after.

Usage example

``` php
    /**
     * @BeforeScenario @alice
     */
    public function visitAlice()
    {
        $pageFactory = $this->getPageFactory();
        $pageFactory->setPageNamespace(static::PAGE_NAMESPACE_ALICE);
        $this->setPageFactory($pageFactory);
    }

    /**
     * @BeforeScenario @bob
     */
    public function visitBob()
    {
        $pageFactory = $this->getPageFactory();
        $pageFactory->setPageNamespace(static::PAGE_NAMESPACE_BOB);
        $this->setPageFactory($pageFactory);
    }
```
