### PR TITLE
making getName() public

### DIFF
--- a/src/SensioLabs/Behat/PageObjectExtension/PageObject/Page.php
+++ b/src/SensioLabs/Behat/PageObjectExtension/PageObject/Page.php
@@ -135,7 +135,7 @@ abstract class Page extends DocumentElement
     /**
      * @return string
      */
-    protected function getName()
+    public function getName()
     {
         return preg_replace('/^.*\\\(.*?)$/', '$1', get_called_class());
     }


### PR DESCRIPTION
I see no reason not to have this method public.
If I want to find out the name, I should be able to.

Say I have a $currentObject instance variable in my FeatureContext. I reuse the same $currentObject. Ex:

$this->currentPageObject = getPage("Homepage");
$this->currentPageObject = getPage("Login");
//...
//if I want to find out what PageObject is $currentPageObject (for debug or whatever), I should be able to do:
$this->currentPageObject->getName();

Currently this fails because getName() is protected. It should be public.
