### PR TITLE
Add extension requirements

### DIFF
--- a/doc/guide/installation.rst
+++ b/doc/guide/installation.rst
@@ -4,6 +4,7 @@ Installation
 This extension requires:
 
 * Behat 3.0+
+* Behat/MinkExtension 2.0@dev+
 
 Through Composer
 ----------------

--- a/doc/guide/installation.rst
+++ b/doc/guide/installation.rst
@@ -18,7 +18,6 @@ The easiest way to keep your suite updated is to use
 
         {
             "require": {
-                "php": ">=5.4.0",
                 "behat/behat": "~3.0",
                 "behat/mink-extension": "~2.0@dev",
                 "behat/mink-goutte-driver": "*"

--- a/doc/guide/installation.rst
+++ b/doc/guide/installation.rst
@@ -17,6 +17,12 @@ The easiest way to keep your suite updated is to use
     .. code-block:: js
 
         {
+            "require": {
+                "php": ">=5.4.0",
+                "behat/behat": "~3.0",
+                "behat/mink-extension": "~2.0@dev",
+                "behat/mink-goutte-driver": "*"
+            },
             "require-dev": {
                 ...
 
@@ -39,6 +45,11 @@ The easiest way to keep your suite updated is to use
           # ...
           extensions:
             SensioLabs\Behat\PageObjectExtension: ~
+            Behat\MinkExtension:
+              base_url: http://environment-url.local/
+              sessions:
+                default:
+                  goutte: ~
 
 Through PHAR
 ------------


### PR DESCRIPTION
Current documentation states that only Behat 3.0+ is required for BehatPageObjectExtension to work.

By following the bootstrap tutorial in the docs, user might be misled when launching Behat for the first time as she will probably end up receiving an exception by telling that a "non-existent parameter 'mink.parameter' " hasn't been specified.

Also as Behat/MinkExtension is an explicit dependency for BehatPageObjectExtension and as Behat/MinkExtension requires at least one driver in order to work, they should be added in the documentation to let users be able to use the extension straight away.
