### PR TITLE
Update the spec to work with newer versions of the Symfony container

### DIFF
--- a/spec/ServiceContainer/PageObjectExtensionSpec.php
+++ b/spec/ServiceContainer/PageObjectExtensionSpec.php
@@ -18,6 +18,9 @@ class PageObjectExtensionSpec extends ObjectBehavior
         $container->setParameter(Argument::cetera())->willReturn(null);
         $container->addCompilerPass(Argument::cetera())->willReturn(null);
         $container->setAlias(Argument::cetera())->willReturn(null);
+        if (method_exists(ContainerBuilder::class, 'fileExists')) {
+            $container->fileExists(Argument::any())->willReturn(false);
+        }
     }
 
     function it_provides_a_config_key()


### PR DESCRIPTION
This is one of the reasons why we shouldn't mock third party dependencies.