### PR TITLE
Save current and expected URL in verifyUrl() for use in exception message

### DIFF
--- a/src/PageObject/Page.php
+++ b/src/PageObject/Page.php
@@ -213,8 +213,11 @@ abstract class Page extends DocumentElement implements PageObject
      */
     protected function verifyUrl(array $urlParameters = array())
     {
-        if ($this->getDriver()->getCurrentUrl() !== $this->getUrl($urlParameters)) {
-            throw new UnexpectedPageException(sprintf('Expected to be on "%s" but found "%s" instead', $this->getUrl($urlParameters), $this->getDriver()->getCurrentUrl()));
+        $expectedUrl = $this->getUrl($urlParameters);
+        $currentUrl = $this->getDriver()->getCurrentUrl();
+
+        if ($currentUrl !== $expectedUrl) {
+            throw new UnexpectedPageException(sprintf('Expected to be on "%s" but found "%s" instead', $expectedUrl, $currentUrl));
         }
     }
 


### PR DESCRIPTION
So that the current URL in the exception message is always the one that failed the ``if`` test.

Issue #100 