### PR TITLE
Fix: Use appropriate class name in example

### DIFF
--- a/doc/guide/working_with_elements.rst
+++ b/doc/guide/working_with_elements.rst
@@ -126,7 +126,7 @@ Accessing custom elements is much like accessing inline ones:
             {
                 return $this->getElement('Search form')->search($keywords);
                 // or (for PHP >= 5.5.0) return $this->getElement(SearchForm::class)->search($keywords);
-                // or (for PHP < 5.5.0) return $this->getElement('Page\\Homepage')->search($keywords);
+                // or (for PHP < 5.5.0) return $this->getElement('Page\\SearchForm')->search($keywords);
             }
         }
 


### PR DESCRIPTION
This PR

* [x] fixes a class name reference in an example