### PR TITLE
Fix: Remove examples for PHP 5

### DIFF
--- a/doc/guide/working_with_elements.rst
+++ b/doc/guide/working_with_elements.rst
@@ -125,8 +125,7 @@ Accessing custom elements is much like accessing inline ones:
             public function search($keywords)
             {
                 return $this->getElement('Search form')->search($keywords);
-                // or (for PHP >= 5.5.0) return $this->getElement(SearchForm::class)->search($keywords);
-                // or (for PHP < 5.5.0) return $this->getElement('Page\\SearchForm')->search($keywords);
+                // or return $this->getElement(SearchForm::class)->search($keywords);
             }
         }
 

--- a/doc/guide/working_with_page_objects.rst
+++ b/doc/guide/working_with_page_objects.rst
@@ -107,10 +107,7 @@ From version 2.1 it is possibile to use ``getPage()`` method with page FQCN as f
              */
             public function iSearchFor($keywords)
             {
-                // For PHP >= 5.5.0
                 $this->getPage(Homepage::class)->search($keywords);
-                // For PHP < 5.5.0
-                $this->getPage('Page\\Homepage')->search($keywords);
             }
         }
 


### PR DESCRIPTION
This PR

* [x] removes examples from the documentation which are intended for PHP 5