### PR TITLE
Fix: Remove return type annotation

### DIFF
--- a/src/Context/PageObjectAware.php
+++ b/src/Context/PageObjectAware.php
@@ -8,8 +8,6 @@ interface PageObjectAware
 {
     /**
      * @param PageObjectFactory $pageObjectFactory
-     *
-     * @return null
      */
     public function setPageObjectFactory(PageObjectFactory $pageObjectFactory);
 }


### PR DESCRIPTION
This PR

* removes a return type annotation

💁‍♂️ The implementation within this repository doesn't return anything, and probably no other implementation does. 

https://github.com/sensiolabs/BehatPageObjectExtension/blob/163c768e933cc4bcf247fdea251ca723e7cd1893/src/Context/PageObjectContext.php#L49-L55

