### PR TITLE
Replaced behat/mink-extension in favor of friends-of-behat/mink-exten…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "php": "^7.2",
         "behat/behat": "^3.3",
         "behat/mink": "^1.7",
-        "behat/mink-extension": "^2.2",
+        "friends-of-behat/mink-extension": "^2.2",
         "ocramius/proxy-manager": "^2.1.1"
     },
     "require-dev": {


### PR DESCRIPTION
…sion

As per https://github.com/Behat/MinkExtension/pull/360#issuecomment-631583136

See also https://github.com/Behat/Behat/issues/1296

The reasons behind this change - apart from the "obvious" ones - is that no one would be able to do this switch as long as this library holds the behat extension and not the FOB one.