### PR TITLE
Remove unused composer/package-versions-deprecated dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,7 @@
         "behat/behat": "^3.8",
         "behat/mink": "^1.7",
         "friends-of-behat/mink-extension": "^2.2",
-        "friendsofphp/proxy-manager-lts": "^1.0.2",
-        "composer/package-versions-deprecated": "^1.11.9"
+        "friendsofphp/proxy-manager-lts": "^1.0.2"
     },
     "require-dev": {
         "behat/mink-goutte-driver": "^1.2",


### PR DESCRIPTION
That package is a composer plugin, which requires users to allow it in composer 2.2+, which will annoy them especially if the plugin is not needed.

The package is also being faded out in favor of the composer-runtime-api of Composer 2 (see https://github.com/symfony/symfony/issues/44726).