### PR TITLE
Remove PHP 8.1 reflection deprecations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
         name: Build and test
         strategy:
             matrix:
-                php: [7.2, 7.3, 7.4, 8.0]
+                php: [7.2, 7.3, 7.4, 8.0, 8.1]
                 deps: [high]
                 include:
                     -   php: 8.0

--- a/src/Context/Argument/PageObjectArgumentResolver.php
+++ b/src/Context/Argument/PageObjectArgumentResolver.php
@@ -87,6 +87,10 @@ class PageObjectArgumentResolver implements ArgumentResolver
      */
     private function getClassName(\ReflectionParameter $parameter)
     {
-        return $parameter->getClass() ? $parameter->getClass()->name : null;
+        if (\PHP_VERSION_ID < 80000) {
+            return $parameter->getClass() ? $parameter->getClass()->getName() : null;
+        }
+
+        return $parameter->getType() ? $parameter->getType()->getName() : null;
     }
 }


### PR DESCRIPTION
Hi, I know that [already exists a PR](https://github.com/sensiolabs/BehatPageObjectExtension/pull/141) that fix this but it seems "busy" for a few months, I'm using this library in my projects and I want to upgrade it to PHP8.1.

I created this PR to solve reflection deprecations in PHP 8.1 so that they can be used in PHP 7.x as well.

I tested it in projects with PHP 8.1 and 7.x ;)