### PR TITLE
Use generics annotations in getPage() to help static analysis

### DIFF
--- a/src/Context/PageObjectContext.php
+++ b/src/Context/PageObjectContext.php
@@ -15,9 +15,11 @@ class PageObjectContext implements Context, PageObjectAware
     private $pageObjectFactory = null;
 
     /**
-     * @param string $name
+     * @template T of Page
      *
-     * @return Page
+     * @param class-string<T> $name
+     *
+     * @return T
      *
      * @throws \RuntimeException
      */

--- a/src/PageObject/Factory.php
+++ b/src/PageObject/Factory.php
@@ -5,9 +5,11 @@ namespace SensioLabs\Behat\PageObjectExtension\PageObject;
 interface Factory
 {
     /**
-     * @param string $name
+     * @template T of Page
      *
-     * @return Page
+     * @param class-string<T> $name
+     *
+     * @return T
      */
     public function createPage($name);
 


### PR DESCRIPTION
This PR solves the following issue.

If in a Context that extends PageObjectContext I write:

```
private function getLoginPage(): LoginPage
{
    return $this->getPage(LoginPage::class);
}
```

Both PHPStan and PHPStorm emit a warning. PHPStan warning message is: `phpstan: Method Behat\Context\Ui\User\ChangePasswordContext::getLoginPage() should return Behat\Page\User\LoginPage but returns SensioLabs\Behat\PageObjectExtension\PageObject\Page.`

My change allows static analysis to infer the right return type.